### PR TITLE
fix: parse flags before accessing *port

### DIFF
--- a/hl7proxy.go
+++ b/hl7proxy.go
@@ -203,9 +203,9 @@ func main() {
 	var headers flagsStringsArray = make(flagsStringsArray, 0)
 	flag.Var(&headers, "header", "Additional HTTP headers in format 'Header: value'")
 
-	listenStr := fmt.Sprintf(":%d", *port)
-
 	flag.Parse()
+
+	listenStr := fmt.Sprintf(":%d", *port)
 
 	if *configId == "" {
 		fmt.Printf("No required -config flag is provided. Usage:\n")


### PR DESCRIPTION
The port could not be set via the console parameters because the port flag was accessed before the flags were parsed.